### PR TITLE
Fixed AV2-1181: M2.1.0-rc1 No time stamp in created_at for Avatax logs

### DIFF
--- a/view/adminhtml/ui_component/avatax_log_listing.xml
+++ b/view/adminhtml/ui_component/avatax_log_listing.xml
@@ -161,6 +161,7 @@
                     <item name="component" xsi:type="string">Magento_Ui/js/grid/columns/date</item>
                     <item name="dataType" xsi:type="string">date</item>
                     <item name="label" xsi:type="string" translate="true">Created</item>
+                    <item name="dateFormat" xsi:type="string">MMM d, y h:mm a</item>
                 </item>
             </argument>
         </column>


### PR DESCRIPTION
- Fixed date format
