### PR TITLE
Fixed AV2-1176: Magento 2.1.0-rc1. Order review page is unreachable w…

### DIFF
--- a/Api/Payment/PaymentDetailsExtensionInterface.php
+++ b/Api/Payment/PaymentDetailsExtensionInterface.php
@@ -30,5 +30,5 @@ interface PaymentDetailsExtensionInterface extends \Magento\Checkout\Api\Data\Pa
      * @param \Magento\Quote\Api\Data\AddressInterface $address
      * @return $this
      */
-    public function setValidatedAddress($address);
+    public function setValidatedAddress(\Magento\Quote\Api\Data\AddressInterface $address);
 }

--- a/Model/Payment/PaymentDetailsExtension.php
+++ b/Model/Payment/PaymentDetailsExtension.php
@@ -39,7 +39,7 @@ class PaymentDetailsExtension extends \Magento\Framework\Api\AbstractSimpleObjec
      * @param \Magento\Quote\Api\Data\AddressInterface $address
      * @return $this
      */
-    public function setValidatedAddress($address)
+    public function setValidatedAddress(\Magento\Quote\Api\Data\AddressInterface $address)
     {
         $this->setData('validated_address', $address);
         return $this;


### PR DESCRIPTION
…ith installed Avatax. Checkout can't be completed
- Fixed implementation of PaymentDetailsExtensionInterface (Magento 2.0 not generate parameter type in the interface)
