### PR TITLE
Fix load order

### DIFF
--- a/etc/module.xml
+++ b/etc/module.xml
@@ -2,5 +2,8 @@
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
     <module name="Astound_AvaTax" setup_version="0.5.0">
+        <sequence>
+            <module name="Magento_Tax"/>
+        </sequence>
     </module>
 </config>


### PR DESCRIPTION
If module dependencies are not properly
set, it will cause errors during magento
schema installation.
